### PR TITLE
imp(derive): add Clone directive to ProfilerGuardBuilder

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -31,6 +31,7 @@ pub struct Profiler {
     blocklist_segments: Vec<(usize, usize)>,
 }
 
+#[derive(Clone)]
 pub struct ProfilerGuardBuilder {
     frequency: c_int,
     #[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64")))]


### PR DESCRIPTION
@YangKeao As the ProfilerGuardBuilder is not available in 0.6.0, do you have an ETA for a new release?